### PR TITLE
use web_user.id and commcare_user.hq_user_id to join instead of email

### DIFF
--- a/models/DM_DB/DM/Views/VW_TABLEAU_CLINIC_FILTER.sql
+++ b/models/DM_DB/DM/Views/VW_TABLEAU_CLINIC_FILTER.sql
@@ -22,7 +22,7 @@ state_user as (
 tableau_users_fixture as 
 (
 
-    select email, 'HQ/' || username as username from dm_table_data_web_users
+    select id, 'HQ/' || username as username from dm_table_data_web_users
 ),
 
 user_clinic as
@@ -35,7 +35,7 @@ user_clinic as
             else ccu.commcare_location_ids
         end as location_list 
         
-        dm_table_data_commcare_user ccu inner join tableau_users_fixture tuf on upper(tuf.id) = upper(ccu.hq_user_id) left join state_user su on su.case_id = ccu.case_id
+        from dm_table_data_commcare_user ccu inner join tableau_users_fixture tuf on upper(tuf.id) = upper(ccu.hq_user_id) left join state_user su on su.case_id = ccu.case_id
     ),
 
 flat_list as (

--- a/models/DM_DB/DM/Views/VW_TABLEAU_CLINIC_FILTER.sql
+++ b/models/DM_DB/DM/Views/VW_TABLEAU_CLINIC_FILTER.sql
@@ -25,14 +25,6 @@ tableau_users_fixture as
     select email, 'HQ/' || username as username from dm_table_data_web_users
 ),
 
-
-recent_user as
-    (
-
-        select max(date_opened) max_date, email from dm_table_data_commcare_user group by email
-    ),
-
-
 user_clinic as
     (
         select 
@@ -43,8 +35,7 @@ user_clinic as
             else ccu.commcare_location_ids
         end as location_list 
         
-        from dm_table_data_commcare_user ccu inner join recent_user rc on ccu.email = rc.email and ccu.date_opened = rc.max_date
-        inner join tableau_users_fixture tuf on upper(tuf.email) = upper(ccu.email) left join state_user su on su.case_id = ccu.case_id and su.date_opened = rc.max_date
+        dm_table_data_commcare_user ccu inner join tableau_users_fixture tuf on upper(tuf.id) = upper(ccu.hq_user_id) left join state_user su on su.case_id = ccu.case_id
     ),
 
 flat_list as (


### PR DESCRIPTION
[Use case_commcare_user.hq_user_id = web_user.id for join in VW_TABLEAU_CLINIC_FILTER](https://dimagi.atlassian.net/browse/UDA-1892)

Updates made:

- Removed logic for recent_user - group by email and pick the most recent date_opened
- In the clinic_list cte, remove join between recent_user and commcare_user table completely
- In the clinic_list cte, join commcare_user table with tuf (from web_user) using web_user.id = commcare_user.hq_user_id